### PR TITLE
backport: exec: add llvm backend support (#10)

### DIFF
--- a/exec/context.go
+++ b/exec/context.go
@@ -22,6 +22,10 @@ type ErrFuncNotFound struct {
 func (e *ErrFuncNotFound) Error() string {
 	return fmt.Sprintf("%s not found", e.Name)
 }
+func (e *ErrFuncNotFound) Is(err error) bool {
+	err1, ok := err.(*ErrFuncNotFound)
+	return ok && err1.Name == e.Name
+}
 
 // ContextConfig configures an execution context
 type ContextConfig struct {

--- a/runtime/emscripten/resolver.go
+++ b/runtime/emscripten/resolver.go
@@ -22,6 +22,11 @@ const (
 	stackSize = 256 << 10 // 256KB
 )
 
+var (
+	errMallocNotFound = &exec.ErrFuncNotFound{Name: "_malloc"}
+	errFreeNotFound   = &exec.ErrFuncNotFound{Name: "_free"}
+)
+
 func unimplemented(symbol string) {
 	exec.Throw(exec.NewTrap(fmt.Sprintf("%s not implemented", symbol)))
 }
@@ -244,6 +249,11 @@ func errno(n int32) uint32 {
 // memory must be freed either by Free or by wasm runtime
 func Malloc(ctx exec.Context, size int) (uint32, error) {
 	ret, err := ctx.Exec("_malloc", []int64{int64(size)})
+
+	if errors.Is(err, errMallocNotFound) {
+		ret, err = ctx.Exec("malloc", []int64{int64(size)})
+	}
+
 	if err != nil {
 		return 0, err
 	}
@@ -256,5 +266,9 @@ func Malloc(ctx exec.Context, size int) (uint32, error) {
 // Free call free on wasm runtime
 func Free(ctx exec.Context, ptr uint32) error {
 	_, err := ctx.Exec("_free", []int64{int64(ptr)})
+
+	if errors.Is(err, errFreeNotFound) {
+		_, err = ctx.Exec("free", []int64{int64(ptr)})
+	}
 	return err
 }

--- a/runtime/wasi/resolver.go
+++ b/runtime/wasi/resolver.go
@@ -3,37 +3,37 @@ package wasi
 import "github.com/xuperchain/xvm/exec"
 
 var resolver = exec.MapResolver(map[string]interface{}{
-	"wasi_unstable.fd_prestat_get": func(ctx exec.Context, x, y uint32) uint32 {
+	"wasi_snapshot_preview1.fd_prestat_get": func(ctx exec.Context, x, y uint32) uint32 {
 		return 8
 	},
-	"wasi_unstable.fd_fdstat_get": func(ctx exec.Context, x, y uint32) uint32 {
+	"wasi_snapshot_preview1.fd_fdstat_get": func(ctx exec.Context, x, y uint32) uint32 {
 		return 8
 	},
-	"wasi_unstable.fd_prestat_dir_name": func(ctx exec.Context, x, y, z uint32) uint32 {
+	"wasi_snapshot_preview1.fd_prestat_dir_name": func(ctx exec.Context, x, y, z uint32) uint32 {
 		return 8
 	},
-	"wasi_unstable.fd_close": func(ctx exec.Context, x uint32) uint32 {
+	"wasi_snapshot_preview1.fd_close": func(ctx exec.Context, x uint32) uint32 {
 		return 8
 	},
-	"wasi_unstable.fd_seek": func(ctx exec.Context, x, y, z, w uint32) uint32 {
+	"wasi_snapshot_preview1.fd_seek": func(ctx exec.Context, x, y, z, w uint32) uint32 {
 		return 8
 	},
-	"wasi_unstable.fd_write": func(ctx exec.Context, x, y, z, w uint32) uint32 {
+	"wasi_snapshot_preview1.fd_write": func(ctx exec.Context, x, y, z, w uint32) uint32 {
 		return 8
 	},
-	"wasi_unstable.environ_sizes_get": func(ctx exec.Context, x, y uint32) uint32 {
+	"wasi_snapshot_preview1.environ_sizes_get": func(ctx exec.Context, x, y uint32) uint32 {
 		return 0
 	},
-	"wasi_unstable.environ_get": func(ctx exec.Context, x, y uint32) uint32 {
+	"wasi_snapshot_preview1.environ_get": func(ctx exec.Context, x, y uint32) uint32 {
 		return 0
 	},
-	"wasi_unstable.args_sizes_get": func(ctx exec.Context, x, y uint32) uint32 {
+	"wasi_snapshot_preview1.args_sizes_get": func(ctx exec.Context, x, y uint32) uint32 {
 		return 0
 	},
-	"wasi_unstable.args_get": func(ctx exec.Context, x, y uint32) uint32 {
+	"wasi_snapshot_preview1.args_get": func(ctx exec.Context, x, y uint32) uint32 {
 		return 0
 	},
-	"wasi_unstable.proc_exit": func(ctx exec.Context, x uint32) uint32 {
+	"wasi_snapshot_preview1.proc_exit": func(ctx exec.Context, x uint32) uint32 {
 		exec.Throw(exec.NewTrap("exit"))
 		return 0
 	},


### PR DESCRIPTION
## Description

cherry-pick changes from llvm backend support  for test 
this pull request is issued as semantics of memory grow changes and memory_grow for legacy fastcomp backend is not supported.
it can be simply reverted and rebase to main if llvm_backend is merged into main.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Brief of your solution

Please describe your solution to solve the issue or feature request.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
